### PR TITLE
fix(core): fix post path error

### DIFF
--- a/packages/builder/core/src/plugins/post-loader/posts.ts
+++ b/packages/builder/core/src/plugins/post-loader/posts.ts
@@ -1,6 +1,7 @@
 import type { BuilderPlugin } from '@blog/types';
 import { lookItUp } from 'look-it-up';
 import { join } from 'path';
+import { realpath } from 'fs/promises';
 import { normalize } from '@blog/node';
 import { getImportCode } from '@blog/parser';
 
@@ -38,12 +39,13 @@ export const PostsLoader = (): BuilderPlugin => ({
         }
 
         const postDir = await lookItUp('node_modules/@blog/posts', args.resolveDir);
+        const realPostDir = await realpath(postDir ?? '');
 
         return {
           namespace: pluginName,
           sideEffects: false,
           external: false,
-          path: postDir ?? '',
+          path: realPostDir,
         };
       });
 

--- a/packages/posts/package.json
+++ b/packages/posts/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/xiaoboost/blog"
   },
   "dependencies": {
+    "@blog/context": "workspace:*",
     "@blog/mdx-code-block-typescript": "workspace:*",
     "@blog/mdx-font-block": "workspace:*",
     "@blog/template-post": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,11 +453,13 @@ importers:
 
   packages/posts:
     specifiers:
+      '@blog/context': workspace:*
       '@blog/mdx-code-block-typescript': workspace:*
       '@blog/mdx-font-block': workspace:*
       '@blog/template-post': workspace:*
       '@blog/types': workspace:*
     dependencies:
+      '@blog/context': link:../builder/context
       '@blog/mdx-code-block-typescript': link:../components/code-block-typescript
       '@blog/mdx-font-block': link:../components/font-block
       '@blog/template-post': link:../templates/post


### PR DESCRIPTION
之前在监听的时候，每个 md 文件对应了两个路径，一个真实路径，一个是符号路径，导致每次修改会触发两次重编译。